### PR TITLE
fix: disable microphone button, show only on chatgpt and anthropic website

### DIFF
--- a/apps/extension/contents/chatgpt-microphone.tsx
+++ b/apps/extension/contents/chatgpt-microphone.tsx
@@ -3,73 +3,22 @@ import { useStorage } from '@plasmohq/storage/hook';
 import { WhisperingError, recorderStateToIcons, type RecorderState } from '@repo/shared';
 import cssText from 'data-text:~/style.css';
 import { Effect } from 'effect';
-import type {
-	PlasmoCSConfig,
-	PlasmoGetInlineAnchorList,
-	PlasmoGetStyle,
-	PlasmoMountShadowHost,
-} from 'plasmo';
+import type { PlasmoCSConfig, PlasmoGetInlineAnchor, PlasmoGetStyle } from 'plasmo';
 import { renderErrorAsNotification } from '~lib/errors';
 import { NotificationServiceContentLive } from '~lib/services/NotificationServiceContentLive';
 import { STORAGE_KEYS } from '~lib/services/extension-storage';
 import type * as ToggleRecording from '../background/messages/contents/toggleRecording';
 
-export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
-	const allEditableElements = document.querySelectorAll(
-		[
-			// "input[type='text']",
-			// "input[type='search']",
-			// "input[type='email']",
-			// "input[type='url']",
-			// "input[type='tel']",
-			// "input[type='password']",
-			// "input[type='number']",
-			// 'input:not([type])',
-			'textarea',
-			'[contenteditable="true"]',
-			'[contenteditable=""]',
-		].join(', '),
-	) as NodeListOf<HTMLElement>;
-
-	const editableElements = Array.from(allEditableElements).filter((element) => {
-		const style = window.getComputedStyle(element);
-		return (
-			style.display !== 'none' &&
-			style.visibility !== 'hidden' &&
-			!element.disabled &&
-			!element.readOnly &&
-			element.offsetParent !== null &&
-			element.getAttribute('aria-readonly') !== 'true' &&
-			element.getAttribute('aria-disabled') !== 'true'
-		);
-	});
-
-	return editableElements.map((element) => ({
+export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {
+	const element = document.querySelector('#prompt-textarea')?.closest('div');
+	return {
 		element,
 		insertPosition: 'afterend',
-	}));
-};
-
-export const mountShadowHost: PlasmoMountShadowHost = ({ shadowHost, anchor, mountState }) => {
-	if (!anchor?.element) return;
-	const editableElement = anchor.element as HTMLElement;
-
-	const wrapper = document.createElement('div');
-	wrapper.style.display = 'flex';
-	wrapper.style.alignItems = 'center';
-
-	wrapper.style.width = '100%';
-	editableElement.style.width = '100%';
-
-	editableElement.parentNode?.insertBefore(wrapper, editableElement);
-	wrapper.appendChild(editableElement);
-	wrapper.appendChild(shadowHost);
-
-	// mountState?.observer?.disconnect(); // OPTIONAL DEMO: stop the observer as needed
+	};
 };
 
 export const config: PlasmoCSConfig = {
-	matches: ['https://claude.ai/*'],
+	matches: ['https://chatgpt.com/*'],
 	all_frames: true,
 };
 

--- a/apps/extension/contents/microphone.tsx
+++ b/apps/extension/contents/microphone.tsx
@@ -69,7 +69,7 @@ export const mountShadowHost: PlasmoMountShadowHost = ({ shadowHost, anchor, mou
 };
 
 export const config: PlasmoCSConfig = {
-	matches: ['<all_urls>'],
+	matches: ['https://www.chatgpt.com/*', 'https://claude.ai/*'],
 	all_frames: true,
 };
 


### PR DESCRIPTION
I accidentally had pushed the Chrome extension to the web store before it was ready and wanted to get this fix out as soon as possible!

For now, I'm disabling injecting the microphone button in all websites EXCEPT `chatgpt.com` and `claude.ai`. This will fix many of the errors people are having as it was unintentional functionality.

Please let me know if people are interested in restoring the button on websites other than `chatgpt.com` and `claude.ai`. I will create adapters for those desired websites.

closes
- Messing up UI for Bing #121
- "Oops, an error occurred!" When uploading an image on chatGPT #120
- Whispering not working on Paymo app field #123
- Update Breaks Google sheets #118