### PR TITLE
fix: conditionally include accessibility-sys and core-foundation-sys only if target os is macos

### DIFF
--- a/apps/app/src-tauri/Cargo.toml
+++ b/apps/app/src-tauri/Cargo.toml
@@ -19,8 +19,10 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.6.1", features = [ "os-all", "updater", "notification-all", "window-set-size", "fs-write-file", "dialog-save", "system-tray", "global-shortcut-all", "clipboard-write-text", "shell-open", "icon-png"] }
 enigo = "0.2.1"
-accessibility-sys = "0.1.3"
-core-foundation-sys = "0.8.6"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+accessibility-sys =  "0.1.3"
+core-foundation-sys =  "0.8.6"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/apps/app/src-tauri/src/main.rs
+++ b/apps/app/src-tauri/src/main.rs
@@ -1,8 +1,12 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(target_os = "macos")]
 mod accessibility;
+
+#[cfg(target_os = "macos")]
 use accessibility::is_macos_accessibility_enabled;
+
 use tauri::{CustomMenuItem, Manager};
 use tauri::{SystemTray, SystemTrayEvent, SystemTrayMenu};
 


### PR DESCRIPTION
This should ideally fix builds in actions, and continues to solve #19