### PR TITLE
feat: faster enumeration of recorder devices

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "app",
-	"version": "4.2.1",
+	"version": "4.3.0",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/app/src-tauri/Cargo.lock
+++ b/apps/app/src-tauri/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "app"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "accessibility-sys",
  "core-foundation-sys",

--- a/apps/app/src-tauri/Cargo.toml
+++ b/apps/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "4.2.1"
+version = "4.3.0"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/apps/app/src-tauri/tauri.conf.json
+++ b/apps/app/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
 	},
 	"package": {
 		"productName": "Whispering",
-		"version": "4.2.1"
+		"version": "4.3.0"
 	},
 	"tauri": {
 		"allowlist": {

--- a/apps/app/src/lib/services/MediaRecorderServiceWebLive.ts
+++ b/apps/app/src/lib/services/MediaRecorderServiceWebLive.ts
@@ -69,9 +69,9 @@ export const MediaRecorderServiceWebLive = Layer.effect(
 					stream = yield* getStreamForDeviceId(recordingDeviceId).pipe(
 						Effect.catchAll(() =>
 							Effect.gen(function* () {
-								const enumeratingDevicesToast = nanoid();
+								const defaultingToFirstAvailableDeviceToastId = nanoid();
 								yield* toast({
-									id: enumeratingDevicesToast,
+									id: defaultingToFirstAvailableDeviceToastId,
 									variant: 'loading',
 									title: 'No device selected or selected device is not available',
 									description: 'Defaulting to first available audio input device...',
@@ -82,7 +82,7 @@ export const MediaRecorderServiceWebLive = Layer.effect(
 									if (Either.isRight(deviceStream)) {
 										settings.selectedAudioInputDeviceId = device.deviceId;
 										yield* toast({
-											id: enumeratingDevicesToast,
+											id: defaultingToFirstAvailableDeviceToastId,
 											variant: 'info',
 											title: 'Defaulted to first available audio input device',
 											description: device.label,

--- a/apps/app/src/lib/services/MediaRecorderServiceWebLive.ts
+++ b/apps/app/src/lib/services/MediaRecorderServiceWebLive.ts
@@ -1,11 +1,36 @@
+import { settings } from '$lib/stores/settings.svelte.js';
 import { WhisperingError } from '@repo/shared';
 import AudioRecorder from 'audio-recorder-polyfill';
-import { Effect, Layer } from 'effect';
+import { Data, Effect, Either, Layer } from 'effect';
+import { nanoid } from 'nanoid/non-secure';
 import { MediaRecorderService } from './MediaRecorderService.js';
+import { ToastService } from './ToastService.js';
+
+class GetStreamError extends Data.TaggedError('GetStreamError')<{
+	recordingDeviceId: string;
+}> {}
+
+const getStreamForDeviceId = (recordingDeviceId: string) =>
+	Effect.tryPromise({
+		try: async () => {
+			const stream = await navigator.mediaDevices.getUserMedia({
+				audio: {
+					deviceId: { exact: recordingDeviceId },
+					channelCount: 1, // Mono audio is usually sufficient for voice recording
+					sampleRate: 16000, // 16 kHz is a good balance for voice
+					echoCancellation: true,
+					noiseSuppression: true,
+				},
+			});
+			return stream;
+		},
+		catch: () => new GetStreamError({ recordingDeviceId }),
+	});
 
 export const MediaRecorderServiceWebLive = Layer.effect(
 	MediaRecorderService,
 	Effect.gen(function* () {
+		const { toast } = yield* ToastService;
 		let stream: MediaStream | null = null;
 		let mediaRecorder: MediaRecorder | null = null;
 		const recordedChunks: Blob[] = [];
@@ -17,47 +42,61 @@ export const MediaRecorderServiceWebLive = Layer.effect(
 			mediaRecorder = null;
 		};
 
+		const enumerateRecordingDevices = Effect.tryPromise({
+			try: async () => {
+				const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+				const devices = await navigator.mediaDevices.enumerateDevices();
+				stream.getTracks().forEach((track) => track.stop());
+				const audioInputDevices = devices.filter((device) => device.kind === 'audioinput');
+				return audioInputDevices;
+			},
+			catch: (error) =>
+				new WhisperingError({
+					title: 'Error enumerating recording devices',
+					description: 'Please make sure you have given permission to access your audio devices',
+					error: error,
+				}),
+		});
+
 		return {
 			get recordingState() {
 				if (!mediaRecorder) return 'inactive';
 				return mediaRecorder.state;
 			},
-			enumerateRecordingDevices: Effect.tryPromise({
-				try: async () => {
-					const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-					const devices = await navigator.mediaDevices.enumerateDevices();
-					stream.getTracks().forEach((track) => track.stop());
-					const audioInputDevices = devices.filter((device) => device.kind === 'audioinput');
-					return audioInputDevices;
-				},
-				catch: (error) =>
-					new WhisperingError({
-						title: 'Error enumerating recording devices',
-						description: 'Please make sure you have given permission to access your audio devices',
-						error: error,
-					}),
-			}),
+			enumerateRecordingDevices,
 			startRecording: (recordingDeviceId: string) =>
 				Effect.gen(function* () {
-					stream = yield* Effect.tryPromise({
-						try: () =>
-							navigator.mediaDevices.getUserMedia({
-								audio: {
-									deviceId: { exact: recordingDeviceId },
-									channelCount: 1, // Mono audio is usually sufficient for voice recording
-									sampleRate: 16000, // 16 kHz is a good balance for voice
-									echoCancellation: true,
-									noiseSuppression: true,
-								},
+					stream = yield* getStreamForDeviceId(recordingDeviceId).pipe(
+						Effect.catchAll(() =>
+							Effect.gen(function* () {
+								const enumeratingDevicesToast = nanoid();
+								yield* toast({
+									id: enumeratingDevicesToast,
+									variant: 'loading',
+									title: 'No device selected or selected device is not available',
+									description: 'Defaulting to first available audio input device...',
+								});
+								const recordingDevices = yield* enumerateRecordingDevices;
+								for (const device of recordingDevices) {
+									const deviceStream = yield* Effect.either(getStreamForDeviceId(device.deviceId));
+									if (Either.isRight(deviceStream)) {
+										settings.selectedAudioInputDeviceId = device.deviceId;
+										yield* toast({
+											id: enumeratingDevicesToast,
+											variant: 'info',
+											title: 'Defaulted to first available audio input device',
+											description: device.label,
+										});
+										return deviceStream.right;
+									}
+								}
+								return yield* new WhisperingError({
+									title: 'No available audio input devices',
+									description: 'Please make sure you have a microphone connected',
+								});
 							}),
-						catch: (error) =>
-							new WhisperingError({
-								title: 'Error getting media stream',
-								description:
-									'Please make sure you have given permission to access your audio devices',
-								error: error,
-							}),
-					});
+						),
+					);
 					recordedChunks.length = 0;
 					mediaRecorder = new AudioRecorder(stream!, {
 						mimeType: 'audio/webm;codecs=opus',

--- a/apps/app/src/lib/stores/recorder.svelte.ts
+++ b/apps/app/src/lib/stores/recorder.svelte.ts
@@ -7,8 +7,13 @@ import { SetTrayIconService } from '$lib/services/SetTrayIconService';
 import { SetTrayIconServiceDesktopLive } from '$lib/services/SetTrayIconServiceDesktopLive';
 import { SetTrayIconServiceWebLive } from '$lib/services/SetTrayIconServiceWebLive';
 import { ToastServiceLive } from '$lib/services/ToastServiceLive';
-import { recordings, settings } from '$lib/stores';
-import { NotificationService, WhisperingError, type RecorderState } from '@repo/shared';
+import { recordings } from '$lib/stores';
+import {
+	NotificationService,
+	WhisperingError,
+	type RecorderState,
+	type Settings,
+} from '@repo/shared';
 import { Effect } from 'effect';
 import { nanoid } from 'nanoid/non-secure';
 import type { Recording } from '../services/RecordingDbService';
@@ -56,7 +61,7 @@ export const recorder = Effect.gen(function* () {
 				}),
 				Effect.runPromise,
 			),
-		toggleRecording: () =>
+		toggleRecording: (settings: Settings) =>
 			Effect.gen(function* () {
 				if (!settings.apiKey) {
 					return yield* new WhisperingError({
@@ -122,7 +127,7 @@ export const recorder = Effect.gen(function* () {
 						return;
 				}
 			}).pipe(Effect.catchAll(renderErrorAsToast), Effect.runPromise),
-		cancelRecording: () =>
+		cancelRecording: (settings: Settings) =>
 			Effect.gen(function* () {
 				yield* mediaRecorderService.cancelRecording;
 				if (settings.isPlaySoundEnabled) {

--- a/apps/app/src/lib/stores/recorder.svelte.ts
+++ b/apps/app/src/lib/stores/recorder.svelte.ts
@@ -77,19 +77,6 @@ export const recorder = Effect.gen(function* () {
 					});
 				}
 
-				const recordingDevices = yield* mediaRecorderService.enumerateRecordingDevices;
-				const isSelectedDeviceExists = recordingDevices.some(
-					({ deviceId }) => deviceId === settings.selectedAudioInputDeviceId,
-				);
-				if (!isSelectedDeviceExists) {
-					yield* toast({
-						variant: 'info',
-						title: 'Defaulting to first available audio input device...',
-						description: 'No device selected or selected device is not available',
-					});
-					const firstAudioInput = recordingDevices[0].deviceId;
-					settings.selectedAudioInputDeviceId = firstAudioInput;
-				}
 
 				switch (mediaRecorderService.recordingState) {
 					case 'inactive':

--- a/apps/app/src/lib/stores/recorder.svelte.ts
+++ b/apps/app/src/lib/stores/recorder.svelte.ts
@@ -9,7 +9,6 @@ import { SetTrayIconServiceWebLive } from '$lib/services/SetTrayIconServiceWebLi
 import { ToastServiceLive } from '$lib/services/ToastServiceLive';
 import { recordings, settings } from '$lib/stores';
 import { NotificationService, WhisperingError, type RecorderState } from '@repo/shared';
-import { ToastService } from '$lib/services/ToastService';
 import { Effect } from 'effect';
 import { nanoid } from 'nanoid/non-secure';
 import type { Recording } from '../services/RecordingDbService';
@@ -17,7 +16,6 @@ import { renderErrorAsToast } from '../services/errors';
 import stopSoundSrc from './assets/sound_ex_machina_Button_Blip.mp3';
 import startSoundSrc from './assets/zapsplat_household_alarm_clock_button_press_12967.mp3';
 import cancelSoundSrc from './assets/zapsplat_multimedia_click_button_short_sharp_73510.mp3';
-import { goto } from '$app/navigation';
 
 const startSound = new Audio(startSoundSrc);
 const stopSound = new Audio(stopSoundSrc);
@@ -49,7 +47,6 @@ const IS_RECORDING_NOTIFICATION_ID = 'WHISPERING_RECORDING_NOTIFICATION';
 
 export const recorder = Effect.gen(function* () {
 	const mediaRecorderService = yield* MediaRecorderService;
-	const { toast } = yield* ToastService;
 	const { notify } = yield* NotificationService;
 
 	return {
@@ -76,7 +73,6 @@ export const recorder = Effect.gen(function* () {
 						},
 					});
 				}
-
 
 				switch (mediaRecorderService.recordingState) {
 					case 'inactive':

--- a/apps/app/src/lib/stores/settings.svelte.ts
+++ b/apps/app/src/lib/stores/settings.svelte.ts
@@ -13,7 +13,7 @@ import { Effect } from 'effect';
 
 type RegisterShortcutJob = Effect.Effect<void>;
 
-const createSettings = Effect.gen(function* () {
+export const settings = Effect.gen(function* () {
 	const { toast } = yield* ToastService;
 	const registerShortcutsService = yield* RegisterShortcutsService;
 	const settings = createPersistedState({
@@ -38,11 +38,11 @@ const createSettings = Effect.gen(function* () {
 		yield* registerShortcutsService.unregisterAllGlobalShortcuts;
 		yield* registerShortcutsService.registerLocalShortcut({
 			shortcut: settings.value.currentLocalShortcut,
-			callback: recorder.toggleRecording,
+			callback: () => recorder.toggleRecording(settings.value),
 		});
 		yield* registerShortcutsService.registerGlobalShortcut({
 			shortcut: settings.value.currentGlobalShortcut,
-			callback: recorder.toggleRecording,
+			callback: () => recorder.toggleRecording(settings.value),
 		});
 	}).pipe(Effect.catchAll(renderErrorAsToast));
 	jobQueue.addJobToQueue(initialSilentJob).pipe(Effect.runPromise);
@@ -82,7 +82,7 @@ const createSettings = Effect.gen(function* () {
 				yield* registerShortcutsService.unregisterAllLocalShortcuts;
 				yield* registerShortcutsService.registerLocalShortcut({
 					shortcut: settings.value.currentLocalShortcut,
-					callback: recorder.toggleRecording,
+					callback: () => recorder.toggleRecording(settings.value),
 				});
 				yield* toast({
 					variant: 'success',
@@ -105,7 +105,7 @@ const createSettings = Effect.gen(function* () {
 				yield* registerShortcutsService.unregisterAllGlobalShortcuts;
 				yield* registerShortcutsService.registerGlobalShortcut({
 					shortcut: settings.value.currentGlobalShortcut,
-					callback: recorder.toggleRecording,
+					callback: () => recorder.toggleRecording(settings.value),
 				});
 				yield* toast({
 					variant: 'success',
@@ -128,9 +128,7 @@ const createSettings = Effect.gen(function* () {
 			settings.value = { ...settings.value, outputLanguage: newValue };
 		},
 	};
-});
-
-export const settings = createSettings.pipe(
+}).pipe(
 	Effect.provide(window.__TAURI__ ? RegisterShortcutsDesktopLive : RegisterShortcutsWebLive),
 	Effect.provide(ToastServiceLive),
 	Effect.runSync,

--- a/apps/app/src/lib/utils/createPersistedState.svelte.ts
+++ b/apps/app/src/lib/utils/createPersistedState.svelte.ts
@@ -11,20 +11,20 @@ import { Option } from 'effect';
  * @returns {Object} The persisted state.
  * @returns {S.Schema.Type<Schema>} value - The reactive value of the persisted state.
  */
-export function createPersistedState<A, I>({
+export function createPersistedState<TSchema extends S.Schema.AnyNoContext>({
 	key,
 	schema,
 	defaultValue,
 	disableLocalStorage = false,
 }: {
 	key: string;
-	schema: S.Schema<A, I>;
-	defaultValue: A;
+	schema: TSchema;
+	defaultValue: S.Schema.Type<TSchema>;
 	disableLocalStorage?: boolean;
 }) {
 	let value = $state(defaultValue);
 
-	const parseValueFromStorage = (valueFromStorage: string | null) => {
+	const parseValueFromStorage = (valueFromStorage: string | null): S.Schema.Type<TSchema> => {
 		const isEmpty = valueFromStorage === null;
 		if (isEmpty) return defaultValue;
 		const jsonSchema = S.parseJson(schema);
@@ -48,7 +48,7 @@ export function createPersistedState<A, I>({
 		get value() {
 			return value;
 		},
-		set value(newValue: A) {
+		set value(newValue: S.Schema.Type<TSchema>) {
 			value = newValue;
 			if (!disableLocalStorage) localStorage.setItem(key, JSON.stringify(newValue));
 		},

--- a/apps/app/src/routes/(app)/+page.svelte
+++ b/apps/app/src/routes/(app)/+page.svelte
@@ -44,7 +44,7 @@
 	<div class="relative">
 		<WhisperingButton
 			tooltipText="Toggle recording"
-			onclick={recorder.toggleRecording}
+			onclick={() => recorder.toggleRecording(settings)}
 			variant="ghost"
 			class="h-full w-full transform items-center justify-center overflow-hidden duration-300 ease-in-out hover:scale-110 focus:scale-110"
 		>
@@ -62,7 +62,7 @@
 		{#if recorder.recorderState === 'RECORDING'}
 			<WhisperingButton
 				tooltipText="Cancel recording"
-				onclick={recorder.cancelRecording}
+				onclick={() => recorder.cancelRecording(settings)}
 				variant="ghost"
 				size="icon"
 				class="absolute -right-16 bottom-1.5 transform text-2xl hover:scale-110 focus:scale-110"

--- a/apps/app/src/routes/(config)/+layout.svelte
+++ b/apps/app/src/routes/(config)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import NavItems from '$lib/components/NavItems.svelte';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
-	import { recorder } from '$lib/stores';
+	import { recorder, settings } from '$lib/stores';
 	import { cn } from '$lib/utils.js';
 </script>
 
@@ -18,7 +18,7 @@
 		</WhisperingButton>
 		<WhisperingButton
 			tooltipText="Toggle recording"
-			onclick={recorder.toggleRecording}
+			onclick={() => recorder.toggleRecording(settings)}
 			variant="ghost"
 			size="icon"
 			style="view-transition-name: microphone-icon"

--- a/apps/app/src/routes/+layout.svelte
+++ b/apps/app/src/routes/+layout.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-	import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-	import { onNavigate } from '$app/navigation';
+	import { goto, onNavigate } from '$app/navigation';
 	import { sendMessageToExtension } from '$lib/sendMessageToExtension';
 	import { ToastServiceLive } from '$lib/services/ToastServiceLive';
 	import { renderErrorAsToast } from '$lib/services/errors';
-	import { recorder, recorderState } from '$lib/stores';
+	import { recorder, recorderState, settings } from '$lib/stores';
+	import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 	import { Effect } from 'effect';
 	import { ModeWatcher, mode } from 'mode-watcher';
 	import { onDestroy, onMount } from 'svelte';
 	import type { ToasterProps } from 'svelte-sonner';
 	import { Toaster } from 'svelte-sonner';
 	import '../app.pcss';
-	import { goto } from '$app/navigation';
 
 	onNavigate((navigation) => {
 		if (!document.startViewTransition) return;
@@ -27,8 +26,8 @@
 	let unlisten: UnlistenFn;
 
 	onMount(async () => {
-		window.toggleRecording = recorder.toggleRecording;
-		window.cancelRecording = recorder.cancelRecording;
+		window.toggleRecording = () => recorder.toggleRecording(settings);
+		window.cancelRecording = () => recorder.cancelRecording(settings);
 		window.goto = goto;
 		window.addEventListener('beforeunload', () => {
 			if (recorderState.value === 'RECORDING') {
@@ -36,9 +35,7 @@
 			}
 		});
 		if (window.__TAURI__) {
-			unlisten = await listen('toggle-recording', () => {
-				recorder.toggleRecording();
-			});
+			unlisten = await listen('toggle-recording', () => recorder.toggleRecording(settings));
 		} else {
 			sendMessageToExtension({
 				name: 'external/notifyWhisperingTabReady',
@@ -72,7 +69,7 @@
 
 <button
 	class="xxs:hidden hover:bg-accent hover:text-accent-foreground h-screen w-screen transform duration-300 ease-in-out"
-	on:click={recorder.toggleRecording}
+	on:click={() => recorder.toggleRecording(settings)}
 >
 	<span
 		style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));"

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "extension",
 	"displayName": "Whispering",
-	"version": "4.2.1",
+	"version": "4.3.0",
 	"private": true,
 	"description": "Seamlessly integrate speech-to-text transcriptions on ChatGPT and anywhere on the web. Powered by OpenAI's Whisper API.",
 	"author": "Braden Wong <whispering@bradenwong.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "whispering",
 	"private": true,
-	"version": "4.2.1",
+	"version": "4.3.0",
 	"description": "",
 	"keywords": [],
 	"license": "ISC",


### PR DESCRIPTION
When the microphone start recording, we skips the enumeration of devices and only do so if the selected device no longer exists. This greatly speeds up startup time of recording, since the old method would always enumerate devices even when not necessary.

closes #117 