### PR TITLE
feat: enable window in background

### DIFF
--- a/apps/app/src-tauri/tauri.conf.json
+++ b/apps/app/src-tauri/tauri.conf.json
@@ -105,10 +105,8 @@
 				"resizable": true,
 				"title": "Whispering",
 				"width": 800,
-				"alwaysOnTop": true,
 				"minHeight": 84,
-				"minWidth": 72,
-				"minimizable": false
+				"minWidth": 72
 			}
 		]
 	}


### PR DESCRIPTION
Running `cargo clean` fixed my ealier issues with global shortcut not being triggered when in background. Closes #137