### PR TITLE
hotfix: set sandboxing to false

### DIFF
--- a/apps/app/src-tauri/entitlements.plist
+++ b/apps/app/src-tauri/entitlements.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>com.apple.security.app-sandbox</key>
-    <true/>
+    <false/>
     
     <key>com.apple.security.network.client</key>
     <true/>


### PR DESCRIPTION
Sandbox was previously set to true but ignored. Now, after code signing, it is being set to true, preventing access to the microphone