### PR TITLE
fix: move macos permissions prompt from copy text to write text

### DIFF
--- a/apps/app/src/lib/services/ClipboardService.ts
+++ b/apps/app/src/lib/services/ClipboardService.ts
@@ -16,6 +16,6 @@ export class ClipboardService extends Context.Tag('ClipboardService')<
 		 * - Desktop: This function should trigger a paste action, as if the user had pressed `Ctrl` + `V`.
 		 * - Mobile: This function should trigger a paste action, as if the user had pressed `Paste` in the context menu.
 		 */
-		readonly writeText: (text: string) => Effect.Effect<void, WhisperingError>;
+		readonly writeTextToCursor: (text: string) => Effect.Effect<void, WhisperingError>;
 	}
 >() {}

--- a/apps/app/src/lib/services/ClipboardServiceExtensionLive.ts.ts
+++ b/apps/app/src/lib/services/ClipboardServiceExtensionLive.ts.ts
@@ -7,7 +7,7 @@ export const ClipboardServiceExtensionLive = Layer.succeed(
 	ClipboardService.of({
 		setClipboardText: (text) =>
 			Effect.tryPromise({
-				try: () => navigator.clipboard.writeText(text),
+				try: () => navigator.clipboard.writeTextToCursor(text),
 				catch: (error) =>
 					new WhisperingError({
 						title: 'Unable to write to clipboard',
@@ -15,7 +15,7 @@ export const ClipboardServiceExtensionLive = Layer.succeed(
 						error,
 					}),
 			}),
-		writeText: (text) =>
+		writeTextToCursor: (text) =>
 			Effect.try({
 				try: () => writeTextToCursor(text),
 				catch: (error) =>

--- a/apps/app/src/lib/services/ClipboardServiceWebLive.ts
+++ b/apps/app/src/lib/services/ClipboardServiceWebLive.ts
@@ -8,7 +8,7 @@ export const ClipboardServiceWebLive = Layer.succeed(
 	ClipboardService.of({
 		setClipboardText: (text) =>
 			Effect.tryPromise({
-				try: () => navigator.clipboard.writeText(text),
+				try: () => navigator.clipboard.writeTextToCursor(text),
 				catch: (error) =>
 					new WhisperingError({
 						title: 'Unable to write to clipboard',
@@ -23,7 +23,7 @@ export const ClipboardServiceWebLive = Layer.succeed(
 					}),
 				),
 			),
-		writeText: (text) =>
+		writeTextToCursor: (text) =>
 			sendMessageToExtension({
 				name: 'external/writeTextToCursor',
 				body: { transcribedText: text },

--- a/apps/app/src/lib/stores/recordings.svelte.ts
+++ b/apps/app/src/lib/stores/recordings.svelte.ts
@@ -178,7 +178,7 @@ export const recordings = Effect.gen(function* () {
 
 				// Paste transcription if enabled
 				if (settings.isPasteContentsOnSuccessEnabled) {
-					yield* clipboardService.writeText(transcribedText);
+					yield* clipboardService.writeTextToCursor(transcribedText);
 					yield* toast({
 						variant: 'success',
 						title: 'Pasted transcription!',

--- a/apps/extension/background/messages/external/setClipboardText.ts
+++ b/apps/extension/background/messages/external/setClipboardText.ts
@@ -17,7 +17,7 @@ const setClipboardText = (text: string): Effect.Effect<void, WhisperingError> =>
 			commandName: 'setClipboardText',
 			func: (text) => {
 				try {
-					navigator.clipboard.writeText(text);
+					navigator.clipboard.writeTextToCursor(text);
 					return { isSuccess: true, data: text } as const;
 				} catch (error) {
 					return {

--- a/apps/extension/popup.tsx
+++ b/apps/extension/popup.tsx
@@ -163,7 +163,7 @@ function IndexPage() {
 						<Button
 							className="dark:bg-secondary dark:text-secondary-foreground px-4 py-2"
 							onClick={() => {
-								navigator.clipboard.writeText(copyToClipboardText);
+								navigator.clipboard.writeTextToCursor(copyToClipboardText);
 							}}
 						>
 							<ClipboardIcon className="h-6 w-6" />


### PR DESCRIPTION
closes #243