### PR TITLE
fix: trim beginning and end whitespace in post processing from groq

### DIFF
--- a/apps/app/src/lib/services/TranscriptionServiceGroqLive.ts
+++ b/apps/app/src/lib/services/TranscriptionServiceGroqLive.ts
@@ -76,7 +76,7 @@ export const TranscriptionServiceGroqLive = Layer.succeed(
 						error: data.error,
 					});
 				}
-				return data.text;
+				return data.text.trim();
 			}),
 	}),
 );


### PR DESCRIPTION
Closes #296