### PR TITLE
feat: add replacements tab

### DIFF
--- a/apps/app/src/lib/stores/recordings.svelte.ts
+++ b/apps/app/src/lib/stores/recordings.svelte.ts
@@ -143,8 +143,6 @@ export const recordings = Effect.gen(function* () {
 					// postprocess if replacements are defined
 					const replacementMap = settings.value.replacementMap;
 					let processedText = transcribedText;
-					console.log('processed Text: ', processedText);
-					console.log('replacementMap: ', replacementMap);
 					if (replacementMap) {
 						const pattern = new RegExp(
 							'\\b(' +

--- a/apps/app/src/lib/stores/recordings.svelte.ts
+++ b/apps/app/src/lib/stores/recordings.svelte.ts
@@ -140,9 +140,31 @@ export const recordings = Effect.gen(function* () {
 							),
 						);
 
+					// postprocess if replacements are defined
+					const replacementMap = settings.value.replacementMap;
+					let processedText = transcribedText;
+					console.log('processed Text: ', processedText);
+					console.log('replacementMap: ', replacementMap);
+					if (replacementMap) {
+						const pattern = new RegExp(
+							'\\b(' +
+								Object.keys(replacementMap)
+									//escape special characters and wrap each word with word boundaries
+									.map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+									.join('|') +
+								')\\b',
+							'gi',
+						);
+
+						processedText = processedText.replace(pattern, (match) => {
+							console.log('match: ', match.toLowerCase());
+							return replacementMap[match.toLowerCase()] ?? match;
+						});
+					}
+
 					yield* updateRecording({
 						...recording,
-						transcribedText,
+						transcribedText: processedText,
 						transcriptionStatus: 'DONE',
 					});
 

--- a/apps/app/src/routes/(config)/settings/+layout.svelte
+++ b/apps/app/src/routes/(config)/settings/+layout.svelte
@@ -1,39 +1,41 @@
 <script lang="ts">
-import { Button } from '$lib/components/ui/button';
-import { Separator } from '$lib/components/ui/separator';
-import SidebarNav from './SidebarNav.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Separator } from '$lib/components/ui/separator';
+	import SidebarNav from './SidebarNav.svelte';
 
-const sidebarNavItems = [
-	{ title: 'General', href: '/settings' },
-	{ title: 'Recording', href: '/settings/recording' },
-	{ title: 'Transcription', href: '/settings/transcription' },
-	{ title: 'Shortcuts', href: '/settings/shortcuts' },
-] as const;
+	const sidebarNavItems = [
+		{ title: 'General', href: '/settings' },
+		{ title: 'Recording', href: '/settings/recording' },
+		{ title: 'Transcription', href: '/settings/transcription' },
+		{ title: 'Shortcuts', href: '/settings/shortcuts' },
+		{ title: 'Replacements', href: '/settings/replacements' },
+	] as const;
 
-const isString = (value: unknown): value is string => typeof value === 'string';
-const versionPromise = (async () => {
-	const res = await fetch(
-		'https://api.github.com/repos/braden-w/whispering/releases/latest',
-	);
-	const { html_url: latestReleaseUrl, tag_name: latestVersion } =
-		await res.json();
-	if (!isString(latestVersion) || !isString(latestReleaseUrl)) {
-		throw new Error('Failed to fetch latest version');
-	}
-	if (!window.__TAURI_INTERNALS__)
-		return { isOutdated: false, version: latestVersion } as const;
-	const { getVersion } = await import('@tauri-apps/api/app');
-	const currentVersion = `v${await getVersion()}`;
-	if (latestVersion === currentVersion) {
-		return { isOutdated: false, version: currentVersion } as const;
-	}
-	return {
-		isOutdated: true,
-		latestVersion,
-		currentVersion,
-		latestReleaseUrl,
-	} as const;
-})();
+	const isString = (value: unknown): value is string =>
+		typeof value === 'string';
+	const versionPromise = (async () => {
+		const res = await fetch(
+			'https://api.github.com/repos/braden-w/whispering/releases/latest',
+		);
+		const { html_url: latestReleaseUrl, tag_name: latestVersion } =
+			await res.json();
+		if (!isString(latestVersion) || !isString(latestReleaseUrl)) {
+			throw new Error('Failed to fetch latest version');
+		}
+		if (!window.__TAURI_INTERNALS__)
+			return { isOutdated: false, version: latestVersion } as const;
+		const { getVersion } = await import('@tauri-apps/api/app');
+		const currentVersion = `v${await getVersion()}`;
+		if (latestVersion === currentVersion) {
+			return { isOutdated: false, version: currentVersion } as const;
+		}
+		return {
+			isOutdated: true,
+			latestVersion,
+			currentVersion,
+			latestReleaseUrl,
+		} as const;
+	})();
 </script>
 
 <main class="container flex w-full flex-1 flex-col pb-4 pt-2">

--- a/apps/app/src/routes/(config)/settings/replacements/+page.svelte
+++ b/apps/app/src/routes/(config)/settings/replacements/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Separator } from '$lib/components/ui/separator';
+	import { settings } from '$lib/stores/settings.svelte';
+	import SettingsLabelInput from '../SettingsLabelInput.svelte';
+	import { TrashIcon } from '$lib/components/icons';
+	const replacementMap = $derived(settings.value.replacementMap);
+
+	let originalWord = $state('');
+	let replacementWord = $state('');
+
+	function addReplacement() {
+		if (originalWord && replacementWord) {
+			settings.value = {
+				...settings.value,
+				replacementMap: { ...replacementMap, [originalWord]: replacementWord },
+			};
+		}
+	}
+
+	function remove(key: string) {
+		const { [key]: removed, ...rest } = replacementMap;
+		settings.value = {
+			replacementMap: rest,
+		};
+	}
+</script>
+
+<svelte:head>
+	<title>Configure word replacements - Whispering</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<div>
+		<h3 class="text-lg font-medium">Shortcuts</h3>
+		<p class="text-muted-foreground text-sm">
+			Configure word replacements by defining a word to word mapping.
+		</p>
+	</div>
+	<Separator />
+	<div>
+		{#if Object.keys(replacementMap).length > 0}
+			<div
+				class="grid grid-cols-11 gap-2 px-4 py-2 bg-gray-100 rounded-t-lg font-medium"
+			>
+				<div class="col-span-5">Original Word</div>
+				<div class="col-span-5">Replacement Word</div>
+				<div class="col-span-1 text-center">Delete</div>
+			</div>
+			{#each Object.entries(replacementMap) as [key, value], index}
+				<div
+					class="grid items-center gap-2 grid-cols-11 px-4 py-3 bg-white border-l border-b border-r"
+					class:rounded-b-lg={index ===
+						Object.entries(replacementMap).length - 1}
+				>
+					<span class="col-span-5 truncate">{key}</span>
+					<span class="col-span-5 truncate">{value}</span>
+					<Button
+						class="col-span-1 flex justify-end"
+						onclick={() => remove(key)}><TrashIcon /></Button
+					>
+				</div>
+			{/each}
+		{/if}
+	</div>
+	<div class="grid gap-2 grid-cols-2">
+		<div>
+			<SettingsLabelInput
+				id="replacement-key"
+				label="Original word"
+				type="text"
+				placeholder="Original word"
+				value={originalWord}
+				oninput={({ currentTarget: { value } }) => {
+					originalWord = value;
+				}}
+			/>
+		</div>
+		<div>
+			<SettingsLabelInput
+				id="replacement-key"
+				label="Replacement Word"
+				type="text"
+				placeholder="Replacement Word"
+				value={replacementWord}
+				oninput={({ currentTarget: { value } }) => {
+					replacementWord = value;
+				}}
+			/>
+		</div>
+	</div>
+	<div class="grid gap-2">
+		<Button
+			disabled={!originalWord || !replacementWord}
+			onclick={addReplacement}>Add a replacement mapping</Button
+		>
+	</div>
+</div>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -53,6 +53,9 @@ export const settingsSchema = S.Struct({
 
 	currentLocalShortcut: S.String,
 	currentGlobalShortcut: S.String,
+	replacementMap: S.optionalWith(S.Record({ key: S.String, value: S.String }), {
+		default: () => ({}),
+	}),
 });
 
 export const getDefaultSettings = (platform: 'app' | 'extension') =>
@@ -75,7 +78,8 @@ export const getDefaultSettings = (platform: 'app' | 'extension') =>
 
 		currentLocalShortcut: 'space',
 		currentGlobalShortcut: platform === 'app' ? 'CommandOrControl+Shift+;' : '',
-	}) satisfies Settings;
+		replacementMap: {},
+	} satisfies Settings);
 
 export type Settings = S.Schema.Type<typeof settingsSchema>;
 
@@ -114,7 +118,7 @@ export const effectToResult = <T>(
 	effect: Effect.Effect<T, WhisperingError>,
 ): Effect.Effect<Result<T>> =>
 	effect.pipe(
-		Effect.map((data) => ({ isSuccess: true, data }) as const),
+		Effect.map((data) => ({ isSuccess: true, data } as const)),
 		Effect.catchAll((error) =>
 			Effect.succeed({ isSuccess: false, error } as const),
 		),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -118,7 +118,7 @@ export const effectToResult = <T>(
 	effect: Effect.Effect<T, WhisperingError>,
 ): Effect.Effect<Result<T>> =>
 	effect.pipe(
-		Effect.map((data) => ({ isSuccess: true, data } as const)),
+		Effect.map((data) => ({ isSuccess: true, data }) as const),
 		Effect.catchAll((error) =>
 			Effect.succeed({ isSuccess: false, error } as const),
 		),


### PR DESCRIPTION
Add Word Replacement Feature for Text Transcription

This PR introduces a new replacement tab that allows users to define custom word replacements during text transcription. Users can specify pairs of original words and their desired replacements, which are then automatically applied as a post processing step after transcription.

Key benefits:
- Saves time by allowing users to define replacements once and apply them consistently across all transcriptions
- Improves accuracy by ensuring consistent naming/terminology throughout documents
- Particularly useful for:
  - Standardizing product/company names
  - Replacing acronyms with full names
  - Localizing specific terms
  - Maintaining consistent terminology in technical documentation
  - Anonymizing sensitive information