### PR TITLE
Added OpenAI transcription models choice, default is whisper-1

### DIFF
--- a/apps/app/src/lib/services/index.ts
+++ b/apps/app/src/lib/services/index.ts
@@ -150,6 +150,7 @@ export const userConfiguredServices = (() => {
 					return createOpenaiTranscriptionService({
 						HttpService,
 						apiKey: settings.value['apiKeys.openai'],
+						modelName: settings.value['transcription.openai.model'],
 					});
 				}
 				case 'Groq': {

--- a/apps/app/src/lib/services/transcription/TranscriptionService.openai.ts
+++ b/apps/app/src/lib/services/transcription/TranscriptionService.openai.ts
@@ -9,13 +9,15 @@ import { createWhisperService } from './createWhisperService';
 export function createOpenaiTranscriptionService({
 	HttpService,
 	apiKey,
+	modelName = 'whisper-1',
 }: {
 	HttpService: HttpService;
 	apiKey: string;
+	modelName: string;
 }): TranscriptionService {
 	return createWhisperService({
 		HttpService,
-		modelName: 'whisper-1',
+		modelName: modelName,
 		postConfig: {
 			url: 'https://api.openai.com/v1/audio/transcriptions',
 			headers: {

--- a/apps/app/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/app/src/routes/(config)/settings/transcription/+page.svelte
@@ -15,6 +15,7 @@
 		SUPPORTED_LANGUAGES_OPTIONS,
 		TRANSCRIPTION_SERVICE_OPTIONS,
 		WHISPERING_URL,
+		OPENAI_WHISPER_MODEL_OPTIONS,
 	} from '@repo/shared';
 	import GroqApiKeyInput from '../../-components/GroqApiKeyInput.svelte';
 	import OpenAiApiKeyInput from '../../-components/OpenAiApiKeyInput.svelte';
@@ -49,6 +50,18 @@
 	/>
 
 	{#if settings.value['transcription.selectedTranscriptionService'] === 'OpenAI'}
+		<LabeledSelect
+			id="openai-model"
+			label="OpenAI Model"
+			items={OPENAI_WHISPER_MODEL_OPTIONS}
+			selected={settings.value['transcription.openai.model']}
+			onSelectedChange={(selected) => {
+				settings.value = {
+					...settings.value,
+					'transcription.openai.model': selected,
+				};
+			}}
+		/>
 		<OpenAiApiKeyInput />
 	{:else if settings.value['transcription.selectedTranscriptionService'] === 'Groq'}
 		<LabeledSelect

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -235,6 +235,19 @@ export const INFERENCE_PROVIDER_OPTIONS = INFERENCE_PROVIDERS.map(
 );
 
 // https://platform.openai.com/docs/models
+export const OPENAI_WHISPER_MODELS = [
+	'whisper-1',
+	'gpt-4o-transcribe',
+	'gpt-4o-mini-transcribe',	
+] as const;
+
+export const OPENAI_WHISPER_MODEL_OPTIONS = OPENAI_WHISPER_MODELS.map(
+	(model) => ({
+		value: model,
+		label: model,
+	}),
+);
+
 export const OPENAI_INFERENCE_MODELS = [
 	'gpt-4o',
 	'gpt-4o-mini',

--- a/packages/shared/src/settings/settingsV5.ts
+++ b/packages/shared/src/settings/settingsV5.ts
@@ -8,6 +8,7 @@ import {
 	RECORDING_METHODS,
 	SUPPORTED_LANGUAGES,
 	TRANSCRIPTION_SERVICES,
+	OPENAI_WHISPER_MODELS,
 	type WhisperingSoundNames,
 } from '../constants.js';
 import type { SettingsV4 } from './settingsV4.js';
@@ -59,6 +60,7 @@ export const settingsV5Schema = z.object({
 	'transcription.temperature': z.string(),
 
 	// Service-specific settings
+	'transcription.openai.model': z.enum(OPENAI_WHISPER_MODELS).optional().default('whisper-1'),
 	'transcription.groq.model': z.enum(GROQ_MODELS),
 	'transcription.fasterWhisperServer.serverUrl': z.string(),
 	'transcription.fasterWhisperServer.serverModel': z.string(),
@@ -106,4 +108,5 @@ export const migrateV4ToV5 = (settings: SettingsV4) =>
 		'recording.tauri.selectedAudioInputName': null,
 
 		'apiKeys.elevenlabs': '',
+		'transcription.openai.model': 'whisper-1',
 	} satisfies SettingsV5);


### PR DESCRIPTION
**Changes:**
- Added constants for new OpenAI model options:
  - GPT-4o Transcribe (gpt-4o-transcribe) 
  - GPT-4o Mini Transcribe (gpt-4o-mini-transcribe)
  - Whisper-1 (whisper-1, default legacy model)
- Updated settings schema (V5) to validate model selection
- Modified OpenAI transcription service to handle model parameter
- Implemented migration logic preserving existing configurations

**Impact:**  
- Users can now select between different quality/speed tradeoffs
- Maintains backward compatibility with existing whisper-1 usage
- Sets whisper-1 as default for smooth transition

**Testing Verified:**
- All models work with OpenAI API endpoints
- UI properly displays available model options
- Model parameter correctly passed to transcription service

**Interesting**
The whisper-1 model (the older one) automatically converts any spoken language into the language you specify in the request. But the newer models don't do that — they always transcribe the audio in its original language.
So the legacy still pretty good 😃 