### PR TITLE
fix(tauri): add macOS microphone permissions and cross-platform bundle config

### DIFF
--- a/apps/app/src-tauri/tauri.conf.json
+++ b/apps/app/src-tauri/tauri.conf.json
@@ -17,10 +17,20 @@
 			"icons/icon.ico"
 		],
 		"longDescription": "Seamlessly integrate speech-to-text transcriptions anywhere on your desktop. Powered by OpenAI's Whisper API.",
-		"shortDescription": "",
+		"shortDescription": "Press shortcut → speak → get text. Free and open source ❤️",
 		"createUpdaterArtifacts": true,
 		"macOS": {
 			"entitlements": "entitlements.plist"
+		},
+		"linux": {
+			"appimage": {
+				"bundleMediaFramework": true
+			}
+		},
+		"windows": {
+			"webviewInstallMode": {
+				"type": "downloadBootstrapper"
+			}
 		}
 	},
 	"productName": "Whispering",

--- a/apps/app/src-tauri/tauri.conf.json
+++ b/apps/app/src-tauri/tauri.conf.json
@@ -18,7 +18,10 @@
 		],
 		"longDescription": "Seamlessly integrate speech-to-text transcriptions anywhere on your desktop. Powered by OpenAI's Whisper API.",
 		"shortDescription": "",
-		"createUpdaterArtifacts": true
+		"createUpdaterArtifacts": true,
+		"macOS": {
+			"entitlements": "entitlements.plist"
+		}
 	},
 	"productName": "Whispering",
 	"version": "7.0.0",


### PR DESCRIPTION
## Summary
- Fix macOS microphone permissions not being requested in desktop app
- Add Linux and Windows platform configurations
- Enable audio support for Linux builds

## Problem
The Tauri desktop app wasn't showing up in macOS microphone permissions because the `tauri.conf.json` was missing the macOS entitlements configuration. This prevented the app from requesting microphone access.

## Changes
1. **macOS Fix**: Added `entitlements.plist` configuration to properly request microphone permissions
2. **Linux Support**: Enabled `bundleMediaFramework` for AppImage to include GStreamer for audio recording
3. **Windows Support**: Added WebView2 bootstrapper configuration
4. **App Description**: Added short description for app stores

## Test Plan
- [ ] Build and test macOS app - verify microphone permission prompt appears
- [ ] Build and test Linux AppImage - verify audio recording works
- [ ] Build and test Windows installer - verify WebView2 installation