### PR TITLE
fix: use correct toast ID for transformation completion

### DIFF
--- a/apps/app/src/lib/commands.ts
+++ b/apps/app/src/lib/commands.ts
@@ -651,5 +651,5 @@ async function saveRecordingAndTranscribeTransform({
 
 	rpc.sound.playSoundIfEnabled.execute('transformationComplete');
 
-	await rpc.delivery.deliverTransformationResult.execute({ text: transformationRun.output, toastId });
+	await rpc.delivery.deliverTransformationResult.execute({ text: transformationRun.output, toastId: transformToastId });
 }


### PR DESCRIPTION
## Summary
- Fixed persistent loading spinner issue when transformations complete
- Corrected toast ID variable usage in transformation completion handler

## Problem
The transformation completion was using the wrong toast ID variable (`toastId` instead of `transformToastId`), causing the "Running transformation..." loading spinner to persist indefinitely after transformations completed.

## Solution
Updated the `deliverTransformationResult` call to use the correct `transformToastId` variable that was created specifically for the transformation operation.

## Test plan
- [ ] Start a recording with a transformation selected
- [ ] Complete the recording
- [ ] Verify the "Running transformation..." toast appears
- [ ] Verify the transformation completes and the loading toast is replaced (no persistent spinner)