### PR TITLE
feat: optimize Tauri binary size with Rust compiler flags

### DIFF
--- a/apps/app/src-tauri/Cargo.toml
+++ b/apps/app/src-tauri/Cargo.toml
@@ -44,3 +44,13 @@ core-foundation-sys =  "0.8.7"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 
+[profile.dev]
+incremental = true # Compile your binary in smaller steps.
+
+[profile.release]
+codegen-units = 1 # Allows LLVM to perform better optimization.
+lto = true # Enables link-time-optimizations.
+opt-level = "s" # Prioritizes small binary size. Use `3` if you prefer speed.
+panic = "abort" # Higher performance by disabling panic handlers.
+strip = true # Ensures debug symbols are removed.
+


### PR DESCRIPTION
## Summary
- Add Rust compiler optimization profiles to reduce Tauri app binary size
- Following the official Tauri v2 size optimization guide

## Changes
- Added `[profile.dev]` section with incremental compilation for faster development builds
- Added `[profile.release]` section with multiple size optimizations:
  - `codegen-units = 1`: Better LLVM optimization
  - `lto = true`: Link-time optimizations
  - `opt-level = "s"`: Prioritize small binary size
  - `panic = "abort"`: Remove panic handlers for smaller size
  - `strip = true`: Remove debug symbols

## References
- Tauri Size Optimization Guide: https://v2.tauri.app/concept/size/
- Fixes #574

## Test Plan
- [ ] Build in release mode and verify binary size reduction
- [ ] Ensure app functionality remains intact
- [ ] Check that development builds still work properly